### PR TITLE
fix: 修复设置页拖拽上传支付宝账单文件时重复条目问题

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -325,7 +325,6 @@
         }
 
         setupDragDrop(alipayUploadArea, '.csv');
-        setupDragDrop(alipayUploadArea, '.csv');
         setupDragDrop(wechatUploadArea, '.xlsx,.csv');
 
         // 处理文件选择


### PR DESCRIPTION
## 问题
设置页，拖拽支付宝账单文件上传时，会出现重复记录

<img width="1550" height="1182" alt="image" src="https://github.com/user-attachments/assets/d30befd8-9756-4b96-9e40-3aac2207cfb5" />

## 原因
dragdrop 事件被处理了两次

## 解决
删除重复的 setupDragDrop 调用

## 验证
分支上，拖拽时只出现一条记录
